### PR TITLE
Move checkJavaParserVisitor to BaseTypeVisitor

### DIFF
--- a/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
+++ b/framework/src/main/java/org/checkerframework/common/basetype/BaseTypeVisitor.java
@@ -303,8 +303,8 @@ public class BaseTypeVisitor<Factory extends GenericAnnotatedTypeFactory<?, ?, ?
     @Override
     public void setRoot(CompilationUnitTree root) {
         atypeFactory.setRoot(root);
-        testJointJavacJavaParserVisitor();
         super.setRoot(root);
+        testJointJavacJavaParserVisitor();
     }
 
     @Override

--- a/framework/src/main/java/org/checkerframework/common/initializedfields/InitializedFieldsAnnotatedTypeFactory.java
+++ b/framework/src/main/java/org/checkerframework/common/initializedfields/InitializedFieldsAnnotatedTypeFactory.java
@@ -256,7 +256,7 @@ public class InitializedFieldsAnnotatedTypeFactory extends AccumulationAnnotated
 
         for (GenericAnnotatedTypeFactory<?, ?, ?, ?> defaultValueAtypeFactory :
                 defaultValueAtypeFactories) {
-            defaultValueAtypeFactory.setRoot(root, true);
+            defaultValueAtypeFactory.setRoot(root);
 
             AnnotatedTypeMirror fieldType = defaultValueAtypeFactory.getAnnotatedType(field);
             AnnotatedTypeMirror defaultValueType =


### PR DESCRIPTION
This way, the version of setRoot that takes a boolean isn't required.